### PR TITLE
Auth Routes

### DIFF
--- a/src/controller/project/getProjectsByUserId.spec.ts
+++ b/src/controller/project/getProjectsByUserId.spec.ts
@@ -6,6 +6,7 @@ import { PrismaProjectRepository } from '../../repositories/prisma/prisma-projec
 import { PrismaUsersRepository } from '../../repositories/prisma/prisma-users-repository'
 import { UserRepository } from '../../repositories/user-repository'
 import { randomUUID } from 'crypto'
+import { createAndAuthenticateUser } from '../../utils/create-and-authenticate-user'
 
 let projectRepository: ProjectRepository
 let userRepository: UserRepository
@@ -23,6 +24,8 @@ describe('Get Projets By UserId E2E', () => {
   })
 
   it('should be able to get all projects from an user', async () => {
+    const { token } = await createAndAuthenticateUser(app)
+
     const description = 'ReactProject'
     const link = 'www.google.com.br'
     const tags = ['react', 'node']
@@ -53,9 +56,9 @@ describe('Get Projets By UserId E2E', () => {
       user_id: newUser.id,
     })
 
-    const getProjectsByUserIdResponse = await request(app.server).get(
-      `/projects/${newUser.id}`,
-    )
+    const getProjectsByUserIdResponse = await request(app.server)
+      .get(`/projects/${newUser.id}`)
+      .set('Authorization', `Bearer ${token}`)
 
     expect(getProjectsByUserIdResponse.statusCode).toEqual(200)
     expect(getProjectsByUserIdResponse.body.projects).toHaveLength(2)
@@ -69,9 +72,10 @@ describe('Get Projets By UserId E2E', () => {
   })
 
   it('should not be able to project that user does not exist', async () => {
-    const getProjectsByUserIdResponse = await request(app.server).get(
-      `/projects/${randomUUID()}`,
-    )
+    const { token } = await createAndAuthenticateUser(app)
+    const getProjectsByUserIdResponse = await request(app.server)
+      .get(`/projects/${randomUUID()}`)
+      .set('Authorization', `Bearer ${token}`)
 
     expect(getProjectsByUserIdResponse.statusCode).toEqual(404)
 

--- a/src/controller/project/routes.ts
+++ b/src/controller/project/routes.ts
@@ -4,8 +4,6 @@ import { getProjectsByUserId } from './getProjectsByUserId'
 import { getProjectsById } from './getProjectById'
 import { addImageProject } from './addImageToProject'
 import FastifyMultipart from '@fastify/multipart'
-import path from 'path'
-import fastifyStatic from '@fastify/static'
 import { getProjectsByTags } from './getProjectsByTags'
 import { editProject } from './editProjectById'
 import { deleteProjectById } from './deleteProjectById'
@@ -17,11 +15,6 @@ export async function projectRoutes(app: FastifyInstance) {
       files: 1,
       fileSize: 1000000, // the max file size in bytes
     },
-  })
-
-  app.register(fastifyStatic, {
-    root: path.resolve(__dirname, '..', '..', 'tmp', 'uploads'),
-    prefix: '/project/photo',
   })
 
   app.post('/projects/tags', getProjectsByTags)

--- a/src/controller/project/routes.ts
+++ b/src/controller/project/routes.ts
@@ -9,6 +9,7 @@ import fastifyStatic from '@fastify/static'
 import { getProjectsByTags } from './getProjectsByTags'
 import { editProject } from './editProjectById'
 import { deleteProjectById } from './deleteProjectById'
+import { verifyJWT } from '../middlewares/verifyJwt'
 
 export async function projectRoutes(app: FastifyInstance) {
   app.register(FastifyMultipart, {
@@ -24,7 +25,7 @@ export async function projectRoutes(app: FastifyInstance) {
   })
 
   app.post('/projects/tags', getProjectsByTags)
-  app.get('/projects/:userId', getProjectsByUserId)
+  app.get('/projects/:userId', { onRequest: verifyJWT }, getProjectsByUserId)
   app.get('/project/:projectId', getProjectsById)
 
   app.post('/project/:projectId/photo', addImageProject)

--- a/src/controller/project/routes.ts
+++ b/src/controller/project/routes.ts
@@ -17,13 +17,17 @@ export async function projectRoutes(app: FastifyInstance) {
     },
   })
 
-  app.post('/projects/tags', getProjectsByTags)
+  app.post('/projects/tags', { onRequest: verifyJWT }, getProjectsByTags)
   app.get('/projects/:userId', { onRequest: verifyJWT }, getProjectsByUserId)
-  app.get('/project/:projectId', getProjectsById)
+  app.get('/project/:projectId', { onRequest: verifyJWT }, getProjectsById)
 
-  app.post('/project/:projectId/photo', addImageProject)
-  app.post('/user/:userId/project', createProject)
+  app.post(
+    '/project/:projectId/photo',
+    { onRequest: verifyJWT },
+    addImageProject,
+  )
+  app.post('/user/:userId/project', { onRequest: verifyJWT }, createProject)
 
-  app.put('/project/:projectId/edit', editProject)
-  app.delete('/project/:projectId', deleteProjectById)
+  app.put('/project/:projectId/edit', { onRequest: verifyJWT }, editProject)
+  app.delete('/project/:projectId', { onRequest: verifyJWT }, deleteProjectById)
 }

--- a/src/controller/user/addImageToUser.ts
+++ b/src/controller/user/addImageToUser.ts
@@ -24,7 +24,9 @@ export async function addImageUser(
 
   try {
     const { user } = await addImageToUserUseCase.execute({ userId, photo })
-    return response.status(200).send({ user })
+    return response
+      .status(200)
+      .send({ user: { ...user, password_hash: undefined } })
   } catch (error) {
     if (error instanceof ResourceNotFoundError) {
       return response.status(400).send({ error: 'User was not found !' })

--- a/src/controller/user/editUserById.spec.ts
+++ b/src/controller/user/editUserById.spec.ts
@@ -2,11 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import request from 'supertest'
 import { app } from '../../app'
 import { randomUUID } from 'crypto'
-import { PrismaUsersRepository } from '../../repositories/prisma/prisma-users-repository'
-import { UserRepository } from '../../repositories/user-repository'
 import { createAndAuthenticateUser } from '../../utils/create-and-authenticate-user'
-
-let userRepository: UserRepository
 
 let userAuth: {
   token: string
@@ -15,7 +11,6 @@ let userAuth: {
 
 describe('edit User E2E', () => {
   beforeAll(async () => {
-    userRepository = new PrismaUsersRepository()
     await app.ready()
     userAuth = await createAndAuthenticateUser(app)
   })

--- a/src/controller/user/editUserById.spec.ts
+++ b/src/controller/user/editUserById.spec.ts
@@ -46,7 +46,6 @@ describe('edit User E2E', () => {
         country: 'country',
         id: newUser.id,
         email,
-        password_hash,
       }),
     )
   })

--- a/src/controller/user/editUserById.ts
+++ b/src/controller/user/editUserById.ts
@@ -32,7 +32,9 @@ export async function editUserById(
       userId,
     })
 
-    return response.status(200).send({ user })
+    return response
+      .status(200)
+      .send({ user: { ...user, password_hash: undefined } })
   } catch (error) {
     if (error instanceof ResourceNotFoundError) {
       return response.status(404).send({ error: 'User was not Found !' })

--- a/src/controller/user/getUserByEmail.spec.ts
+++ b/src/controller/user/getUserByEmail.spec.ts
@@ -35,16 +35,9 @@ describe('Get User By email E2E', () => {
         email,
         name,
         surname,
-        password_hash: expect.any(String),
         country: 'brasil',
       }),
     )
-
-    const passwordMatches = await compare(
-      password,
-      getUserByEmailResponse.body.user.password_hash,
-    )
-    expect(passwordMatches).toEqual(true)
   })
 
   test('should not be able to get an user by e-mail that does not exist', async () => {

--- a/src/controller/user/getUserByEmail.ts
+++ b/src/controller/user/getUserByEmail.ts
@@ -21,7 +21,9 @@ export async function getUserByEmail(
     const { user } = await getUserByEmailUseCase.execute({
       email,
     })
-    return response.status(200).send({ user })
+    return response
+      .status(200)
+      .send({ user: { ...user, password_hash: undefined } })
   } catch (error) {
     if (error instanceof ResourceNotFoundError) {
       return response.status(404).send()

--- a/src/controller/user/getUserById.spec.ts
+++ b/src/controller/user/getUserById.spec.ts
@@ -1,12 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import request from 'supertest'
 import { app } from '../../app'
-import { PrismaUsersRepository } from '../../repositories/prisma/prisma-users-repository'
-import { UserRepository } from '../../repositories/user-repository'
 import { createAndAuthenticateUser } from '../../utils/create-and-authenticate-user'
 import { randomUUID } from 'crypto'
-
-let userRepository: UserRepository
 
 let userAuth: {
   token: string
@@ -15,7 +11,6 @@ let userAuth: {
 
 describe('Get User By Id E2E', () => {
   beforeAll(async () => {
-    userRepository = new PrismaUsersRepository()
     await app.ready()
     userAuth = await createAndAuthenticateUser(app)
   })

--- a/src/controller/user/getUserById.spec.ts
+++ b/src/controller/user/getUserById.spec.ts
@@ -3,13 +3,21 @@ import request from 'supertest'
 import { app } from '../../app'
 import { PrismaUsersRepository } from '../../repositories/prisma/prisma-users-repository'
 import { UserRepository } from '../../repositories/user-repository'
+import { createAndAuthenticateUser } from '../../utils/create-and-authenticate-user'
+import { randomUUID } from 'crypto'
 
 let userRepository: UserRepository
+
+let userAuth: {
+  token: string
+  userId: string
+}
 
 describe('Get User By Id E2E', () => {
   beforeAll(async () => {
     userRepository = new PrismaUsersRepository()
     await app.ready()
+    userAuth = await createAndAuthenticateUser(app)
   })
 
   afterAll(async () => {
@@ -17,29 +25,23 @@ describe('Get User By Id E2E', () => {
   })
 
   it('should be able to get an user by ID', async () => {
-    const id = '9600de4f-8d18-4e69-ba7a-ed7fa210618d'
-    const email = 'john_doe@email.com'
-    const name = 'John'
-    const surname = 'Doe'
-    const password_hash = '9600de4f-8d18-4e69-ba7a-ed7fa210618d'
-
-    await userRepository.create({ email, id, name, surname, password_hash })
-
-    const getUserByIdResponse = await request(app.server).get(`/user/${id}`)
+    const getUserByIdResponse = await request(app.server)
+      .get(`/user/${userAuth.userId}`)
+      .set('Authorization', `Bearer ${userAuth.token}`)
 
     expect(getUserByIdResponse.statusCode).toEqual(200)
     expect(getUserByIdResponse.body.user).toEqual(
       expect.objectContaining({
-        id,
+        id: userAuth.userId,
         country: 'brasil',
       }),
     )
   })
 
   it('should not be able to get an user by ID that does exists', async () => {
-    const id = '9999de4f-8d18-4e69-ba7a-ed7fa210618d'
-
-    const getUserByIdResponse = await request(app.server).get(`/user/${id}`)
+    const getUserByIdResponse = await request(app.server)
+      .get(`/user/${randomUUID()}`)
+      .set('Authorization', `Bearer ${userAuth.token}`)
 
     expect(getUserByIdResponse.statusCode).toEqual(404)
     expect(getUserByIdResponse.body.user).toEqual(expect.objectContaining({}))
@@ -48,7 +50,10 @@ describe('Get User By Id E2E', () => {
   it('should not be able to get an user requesting with id that is not uuid', async () => {
     const id = 'id_not_uuid'
 
-    const getUserByIdResponse = await request(app.server).get(`/user/${id}`)
+    const getUserByIdResponse = await request(app.server)
+      .get(`/user/${id}`)
+      .set('Authorization', `Bearer ${userAuth.token}`)
+
     expect(getUserByIdResponse.statusCode).toEqual(400)
 
     expect(getUserByIdResponse.body).toEqual(

--- a/src/controller/user/getUserById.ts
+++ b/src/controller/user/getUserById.ts
@@ -21,7 +21,9 @@ export async function getUserById(
     const { user } = await getUserByIdUseCase.execute({
       id,
     })
-    return response.status(200).send({ user })
+    return response
+      .status(200)
+      .send({ user: { ...user, password_hash: undefined } })
   } catch (error) {
     if (error instanceof ResourceNotFoundError) {
       return response.status(404).send()

--- a/src/controller/user/routes.ts
+++ b/src/controller/user/routes.ts
@@ -5,6 +5,7 @@ import { registerUser } from './registerUser'
 import { editUserById } from './editUserById'
 import { addImageUser } from './addImageToUser'
 import FastifyMultipart from '@fastify/multipart'
+import { verifyJWT } from '../middlewares/verifyJwt'
 
 export async function userRoutes(app: FastifyInstance) {
   app.register(FastifyMultipart, {
@@ -14,8 +15,8 @@ export async function userRoutes(app: FastifyInstance) {
     },
   })
   app.post('/user', registerUser)
-  app.get('/user/:id', getUserById)
-  app.get('/user', getUserByEmail)
-  app.put('/user/:userId/edit', editUserById)
-  app.post('/user/:userId/photo', addImageUser)
+  app.get('/user/:id', { onRequest: verifyJWT }, getUserById)
+  app.get('/user', { onRequest: verifyJWT }, getUserByEmail)
+  app.put('/user/:userId/edit', { onRequest: verifyJWT }, editUserById)
+  app.post('/user/:userId/photo', { onRequest: verifyJWT }, addImageUser)
 }

--- a/src/utils/create-and-authenticate-user.ts
+++ b/src/utils/create-and-authenticate-user.ts
@@ -15,6 +15,7 @@ export async function createAndAuthenticateUser(app: FastifyInstance) {
   })
 
   const { token } = authResponse.body
+  const { id: userId } = authResponse.body.user
 
-  return { token }
+  return { token, userId }
 }

--- a/src/utils/create-and-authenticate-user.ts
+++ b/src/utils/create-and-authenticate-user.ts
@@ -1,0 +1,20 @@
+import { FastifyInstance } from 'fastify/types/instance'
+import request from 'supertest'
+
+export async function createAndAuthenticateUser(app: FastifyInstance) {
+  await request(app.server).post('/user').send({
+    name: 'John',
+    surname: 'Doe',
+    email: 'johndoe@example.com',
+    password: '12345678',
+  })
+
+  const authResponse = await request(app.server).post('/login').send({
+    email: 'johndoe@example.com',
+    password: '12345678',
+  })
+
+  const { token } = authResponse.body
+
+  return { token }
+}


### PR DESCRIPTION
 - Add authentication to all routes that are supposed to be logged in. ✅ 

### Improvements

We could improve the routes now that we are using JWT tokens and limit API resource access.

- [ ] #50

For example: 

Currently, if you are logged in, you can search for a user using the **`get user by id route`** by passing another user's ID as a query parameter.

This happens because the route uses the JWT token just for authentication and not to search for the user.

This would also prevent us from needing to export the `userId` from the create-authenticate-user.ts file, which is used for our tests, and to complete the route path (through query parameters) in the tests.

- [ ] #51 
Also, we should not return user info in the /login route, but that request needs to be aligned with the front-end, @pedrodecf.

These improvements are not done yet since they will require changing the URLs that the front-end sends to us. We are one day away from delivering the project, and including this PR, the routes are safe and without any security leaks.

Let's open an issue in the frontend and backend to address this smoothly
https://github.com/MatheusSanchez/orange-front





